### PR TITLE
docs(Auth): fix token name

### DIFF
--- a/content/docs/auth/introduction.md
+++ b/content/docs/auth/introduction.md
@@ -103,7 +103,7 @@ Once done, you must run the following command to configure the auth package.
 node ace configure @adonisjs/auth --guard=session
 
 # Configure with access tokens guard
-node ace configure @adonisjs/auth --guard=tokens
+node ace configure @adonisjs/auth --guard=access_tokens
 
 # Configure with basic auth guard
 node ace configure @adonisjs/auth --guard=basic_auth


### PR DESCRIPTION
```sh
node ace configure @adonisjs/auth --guard=tokens                                                                          ✘ 1 migrate-adonisjs-to-v6-from-scratch ✭ ◼
[ error ] The selected guard "tokens" is invalid. Select one from: session, access_tokens
```
