### PR TITLE
change error to inputError

### DIFF
--- a/content/docs/reference/edge.md
+++ b/content/docs/reference/edge.md
@@ -228,7 +228,7 @@ The `@inputError` tag provides a better DX for reading validation error messages
 :::
 
 ```edge
-@error('title')
+@inputError('title')
   @each(message in $messages)
     <p>{{ message }}</p>
   @end


### PR DESCRIPTION
### 📚 Description

I found there is a typo error in the Edge.js reference documentation.
Instead of `@inputError`, the documentation mentions `@error`.
This PR fix this.

I did not create any issue before this PR as the fix very small. I did not want to clutter the issue section for a typo.

