### PR TITLE
docs(rate-limiter): replace blockFor to blockDuration in session controller

### DIFF
--- a/content/docs/security/rate-limiter.md
+++ b/content/docs/security/rate-limiter.md
@@ -627,7 +627,7 @@ export default class SessionController {
     const loginLimiter = limiter.use({
       requests: 5,
       duration: '1 min',
-      blockFor: '20 mins'
+      blockDuration: '20 mins'
     })
 
     /**


### PR DESCRIPTION
Hey there!

This PR replaces  blockFor to blockDuration in the docs.
