### PR TITLE
Remove a bug from code sample in verifying_user_credentials.md

### DIFF
--- a/content/docs/auth/verifying_user_credentials.md
+++ b/content/docs/auth/verifying_user_credentials.md
@@ -138,15 +138,15 @@ export default class SessionController {
      * Find a user by email. Return error if a user does
      * not exists
      */ 
-    const user = await User.findBy('email', email)
-    if (!user) {
+    const userFound = await User.findBy('email', email)
+    if (!userFound) {
       response.abort('Invalid credentials')
     }
 
     /**
      * Verify the password using the hash service
      */
-    await hash.verify(user.password, password)
+    await hash.verify(userFound.password, password)
     // delete-end
     // insert-start
     const user = await User.verifyCredentials(email, password)


### PR DESCRIPTION
The code sample in the "Verifying credentials" section contains a duplicate `user` constant declaration, causing the code to fail. I updated it so the first constant, where we look for a matching user, is called `userFound`.

