### PR TITLE
fix: use proper reload prop name for vite config

### DIFF
--- a/content/docs/experimental/vite.md
+++ b/content/docs/experimental/vite.md
@@ -112,7 +112,7 @@ export default defineConfig({
   plugins: [
     adonisjs({
       entrypoints: ['resources/js/app.js'],
-      reloads: ['resources/views/**/*.edge'],
+      reload: ['resources/views/**/*.edge'],
     }),
   ]
 })


### PR DESCRIPTION
Was getting a Typescript error when following along with the docs. It looks like `reloads` should be `reload`.