### PR TITLE
docs: fix typo in HttpExceptionHandler class name

### DIFF
--- a/content/docs/http/routing.md
+++ b/content/docs/http/routing.md
@@ -573,10 +573,7 @@ To display a 404 page to the user, you can catch the `E_ROUTE_NOT_FOUND` excepti
 
 ```ts
 import { errors } from '@adonisjs/core'
-import {
-  HttpContext,
-  ExceptionHandler
-} from '@adonisjs/core/http'
+import { HttpContext, ExceptionHandler } from '@adonisjs/core/http'
 
 export default class HttpExceptionHandler extends ExceptionHandler {
   async handle(error: unknown, ctx: HttpContext) {

--- a/content/docs/http/routing.md
+++ b/content/docs/http/routing.md
@@ -578,7 +578,7 @@ import {
   ExceptionHandler
 } from '@adonisjs/core/http'
 
-export default class HttpExceptionsHandler extends ExceptionHandler {
+export default class HttpExceptionHandler extends ExceptionHandler {
   async handle(error: unknown, ctx: HttpContext) {
     if (error instanceof errors.E_ROUTE_NOT_FOUND) {
       return ctx.view.render('errors/404')


### PR DESCRIPTION
Hi,

I was searching about 404 requests in the docs and found this section:

![image](https://github.com/adonisjs/v6-docs/assets/86885041/659ff4d3-f39b-4548-a732-08a3d02b0600)

It showed the `HttpExceptionsHandler` class but after I checked in the global exception handler, it turns out it should be `HttpExceptionHandler`. Would you mind if I just remove this single letter? Also, I changed the import to a single line.

Thank you!