### PR TITLE
fix: releases link

### DIFF
--- a/content/docs/preface/introduction.md
+++ b/content/docs/preface/introduction.md
@@ -90,7 +90,7 @@ The AdonisJS documentation is written as a reference guide, covering the usage a
 With that said, the documentation extensively covers the usage of available modules and the inner workings of the framework.
 
 ## Recent releases
-Following is the list of recent releases. [Click here](releases.md) to view all the releases.
+Following is the list of recent releases. [Click here](./releases.md) to view all the releases.
 
 ::include{template="partials/recent_releases"}
 


### PR DESCRIPTION
In the [introduction page](https://docs.adonisjs.com/guides/preface/introduction#recent-releases), the link to the list of releases do not work

Putting a relative path to the .md file fixes it
