### PR TITLE
incomplete url fix for markdown links with _ to join .md name in ace …

### DIFF
--- a/content/docs/ace/creating_commands.md
+++ b/content/docs/ace/creating_commands.md
@@ -233,7 +233,7 @@ export default class GreetCommand extends BaseCommand {
 
 ## Dependency injection
 
-Ace commands are constructed and executed using the [IoC container](../../concepts/dependency_injection). Therefore, you can type-hint dependencies on command lifecycle methods and use the `@inject` decorator to resolve them.
+Ace commands are constructed and executed using the [IoC container](../concepts/dependency_injection). Therefore, you can type-hint dependencies on command lifecycle methods and use the `@inject` decorator to resolve them.
 
 For demonstration, let's inject the `UserService` class in all the lifecycle methods.
 

--- a/content/docs/ace/prompts.md
+++ b/content/docs/ace/prompts.md
@@ -18,7 +18,7 @@ Prompts are interactive terminal widgets you can use to accept user input. Ace p
 
 Ace prompts are built with testing in mind. When writing tests, you may trap prompts and respond to them programmatically.
 
-See also: [Testing ace commands](../../testing/console_tests)
+See also: [Testing ace commands](../testing/console_tests)
 
 ## Displaying a prompt
 

--- a/content/docs/ace/tui.md
+++ b/content/docs/ace/tui.md
@@ -8,7 +8,7 @@ Ace terminal UI is powered by the [@poppinss/cliui](https://github.com/poppinss/
 
 The terminal UI primitives are built with testing in mind. When writing tests, you may turn on the `raw` mode to disable colors and formatting and collect all logs in memory to write assertions against them.
 
-See also: [Testing Ace commands](../../testing/console_tests)
+See also: [Testing Ace commands](../testing/console_tests)
 
 ## Displaying log messages
 


### PR DESCRIPTION
Hello! 

I was getting up to speed via the seamlessly crafted adonis6 docs. In the `Ace section`, a number of the hyperlinks weren't working. I noticed that the url was going back one additional folder level `../` than needed. Upon removing the 3 instances I found of this in the above PR, the hyperlinks link correctly to the corresponding `.md` files within the repo itself. The open problem left though that I was unable to figure out was that once one runs `npm run dev`, the url has an `_` instead of a`-` to concatenate the two worded url. For example: https://docs.adonisjs.com/guides/testing/console_tests is now the route and should be https://docs.adonisjs.com/guides/testing/console-tests. Any thoughts on how I can help fix this? Thank you again Adonis team for such an awesome product!

Best,
Hugh B.

