### PR TITLE
fix: path typo

### DIFF
--- a/content/docs/getting_started/deployment.md
+++ b/content/docs/getting_started/deployment.md
@@ -102,7 +102,7 @@ If you are using a deployment platform like Heroku or Cleavr, you may use their 
 Assuming you have created the `.env` file in an `/etc/secrets` directory, you must start your production server as follows.
 
 ```sh
-ENV_PATH=/etc/secrets node build/server.js
+ENV_PATH=/etc/secrets node build/bin/server.js
 ```
 
 The `ENV_PATH` environment variable instructs AdonisJS to look for the `.env` file inside the mentioned directory.


### PR DESCRIPTION
Got an error when running the server, the solution was to fix the path to be `build/bin/server.js`, then the server started properly. And if you look at the Dockerfile defined above in the page, the last line in it says `./bin/server.js`.