### PR TITLE
docs: update pm2 instructions for ES module

### DIFF
--- a/content/docs/getting_started/deployment.md
+++ b/content/docs/getting_started/deployment.md
@@ -115,7 +115,7 @@ You may start the production server by running the `node server.js` file. Howeve
 - It will restart the application, if your app crashes while serving requests.
 - Also, PM2 makes it super simple to run your application in [cluster mode](https://nodejs.org/api/cluster.html#cluster)
 
-Following is an example [pm2 ecosystem file](https://pm2.keymetrics.io/docs/usage/application-declaration) you may use as the starting point.
+`cd` into `build/bin` and initialize a pm2 config file with `pm2 init simple`. If your `package.json` has `type: "module"`, you will need to rename the pm2 config file from `ecosystem.config.js` to `ecosystem.config.cjs` because of a package wide ES modules rule.
 
 ```js
 // title: ecosystem.config.js
@@ -132,9 +132,13 @@ module.exports = {
 }
 ```
 
+Here is more info about how to configure a [pm2 ecosystem file](https://pm2.keymetrics.io/docs/usage/application-declaration).
+
 ```sh
 // title: Start server
 pm2 start ecosystem.config.js
+// or 
+pm2 start ecosystem.config.cjs
 ```
 
 ## Migrating database


### PR DESCRIPTION
I had this error message, I also show what I did to fix it and added the instructions to the docs:

```bash
root@ubuntu-s-1vcpu-1gb-nyc3-01:~/ant-ride-backend/build/bin# ls
console.js  console.js.map  ecosystem.config.js  server.js  server.js.map  test.js  test.js.map

root@ubuntu-s-1vcpu-1gb-nyc3-01:~/ant-ride-backend/build/bin# pm2 start ecosystem.config.js
[PM2][ERROR] File ecosystem.config.js malformated
Error [ERR_REQUIRE_ESM]: require() of ES Module /root/ant-ride-backend/build/bin/ecosystem.config.js from /root/.nvm/versions/node/v20.13.1/lib/node_modules/pm2/lib/Common.js not supported.
ecosystem.config.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead either rename ecosystem.config.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /root/ant-ride-backend/build/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

    at Common.parseConfig (/root/.nvm/versions/node/v20.13.1/lib/node_modules/pm2/lib/Common.js:331:12)
    at API._startJson (/root/.nvm/versions/node/v20.13.1/lib/node_modules/pm2/lib/API.js:934:25)
    at API.start (/root/.nvm/versions/node/v20.13.1/lib/node_modules/pm2/lib/API.js:329:12)
    at /root/.nvm/versions/node/v20.13.1/lib/node_modules/pm2/lib/binaries/CLI.js:291:13
    at /root/.nvm/versions/node/v20.13.1/lib/node_modules/pm2/node_modules/async/internal/withoutIndex.js:8:40 {
  code: 'ERR_REQUIRE_ESM'
}

root@ubuntu-s-1vcpu-1gb-nyc3-01:~/ant-ride-backend/build/bin# ls
console.js  console.js.map  ecosystem.config.js  server.js  server.js.map  test.js  test.js.map

root@ubuntu-s-1vcpu-1gb-nyc3-01:~/ant-ride-backend/build/bin# mv ecosystem.config.js ecosystem.config.cjs

root@ubuntu-s-1vcpu-1gb-nyc3-01:~/ant-ride-backend/build/bin# ls

console.js  console.js.map  ecosystem.config.cjs  server.js  server.js.map  test.js  test.js.map

root@ubuntu-s-1vcpu-1gb-nyc3-01:~/ant-ride-backend/build/bin# pm2 start ecosystem.config.cjs
[PM2][WARN] Applications web-app not running, starting...
[PM2] App [web-app] launched (1 instances)
┌────┬────────────┬─────────────┬─────────┬─────────┬──────────┬────────┬──────┬───────────┬──────────┬──────────┬──────────┬──────────┐
│ id │ name       │ namespace   │ version │ mode    │ pid      │ uptime │ ↺    │ status    │ cpu      │ mem      │ user     │ watching │
├────┼────────────┼─────────────┼─────────┼─────────┼──────────┼────────┼──────┼───────────┼──────────┼──────────┼──────────┼──────────┤
│ 0  │ web-app    │ default     │ 0.0.0   │ cluster │ 5716     │ 0s     │ 0    │ online    │ 0%       │ 43.2mb   │ root     │ disabled │
└────┴────────────┴─────────────┴─────────┴─────────┴──────────┴────────┴──────┴───────────┴──────────┴──────────┴──────────┴──────────┘
root@ubuntu-s-1vcpu-1gb-nyc3-01:~/ant-ride-backend/build/bin#
```