### PR TITLE
docs: Update exception_handling.md

### DIFF
--- a/content/docs/basics/exception_handling.md
+++ b/content/docs/basics/exception_handling.md
@@ -49,7 +49,7 @@ import { errors } from '@vinejs/vine'
 
 export default class HttpExceptionHandler extends ExceptionHandler {
   async handle(error: unknown, ctx: HttpContext) {
-    if (error instanceof errors.E_VALIDATION_EXCEPTION) {
+    if (error instanceof errors.E_VALIDATION_ERROR) {
       ctx.response.status(422).send(error.messages)
       return
     }


### PR DESCRIPTION
In document, there's a snippet code:

```typescript
import { errors } from '@vinejs/vine'

export default class HttpExceptionHandler extends ExceptionHandler {
  async handle(error: unknown, ctx: HttpContext) {
    if (error instanceof errors.E_VALIDATION_EXCEPTION) {
      ctx.response.status(422).send(error.messages)
      return
    }

    return super.handle(error, ctx)
  }
}
```

Actually, vine error only have `E_VALIDATION_ERROR`