### PR TITLE
Fix (docs): Correct method name

### DIFF
--- a/content/docs/security/rate_limiting.md
+++ b/content/docs/security/rate_limiting.md
@@ -637,7 +637,7 @@ export default class SessionController {
      */
     if (error) {
       session.flashAll()
-      session.flashError({
+      session.flashErrors({
         E_TOO_MANY_REQUESTS: `Too many login requests. Try again after ${error.response.availableIn} seconds`
       })
       return response.redirect().back()


### PR DESCRIPTION
session.flashError as the current docs state is not a valid method. The correct method name is session.flashErrors.

