### PR TITLE
chore: Update img.edge to fix broken image source

### DIFF
--- a/templates/elements/img.edge
+++ b/templates/elements/img.edge
@@ -1,6 +1,6 @@
 <figure x-data="zoom">
   @if(node.properties.src.startsWith('http://') || node.properties.src.startsWith('https://'))
-    <img src="node.properties.src" />
+    <img src="{{ node.properties.src }}" />
   @else
     <img src="{{ vite.assetPath(app.relativePath(node.properties.src)) }}" />
   @end


### PR DESCRIPTION
When using the documentation repository, I noticed that images coming from a source were not displayed.

Looking at the component, I noticed that the variable containing the URL could not be transformed, as the URL name was passed as a string.

Here's a fix that solves this problem.