### PR TITLE
Update Inertia middleware example

### DIFF
--- a/content/docs/views-and-templates/inertia.md
+++ b/content/docs/views-and-templates/inertia.md
@@ -518,9 +518,11 @@ import type { HttpContext } from '@adonisjs/core/http'
 import type { NextFn } from '@adonisjs/core/types/http'
 
 export default class MyMiddleware {
-  public async handle({ inertia }: HttpContext, next: NextFn) {
-    inertia.share('appName', 'My App')
-    inertia.share('user', (ctx) => ctx.auth?.user)
+  public async handle({ inertia, auth }: HttpContext, next: NextFn) {
+    inertia.share({ appName: 'My App' })
+    await auth.check()
+    const user = auth.user
+    inertia.share({ user: { id: user?.id, email: user?.email } })
   }
 }
 ```

--- a/content/docs/views-and-templates/inertia.md
+++ b/content/docs/views-and-templates/inertia.md
@@ -519,10 +519,10 @@ import type { NextFn } from '@adonisjs/core/types/http'
 
 export default class MyMiddleware {
   public async handle({ inertia, auth }: HttpContext, next: NextFn) {
-    inertia.share({ appName: 'My App' })
-    await auth.check()
-    const user = auth.user
-    inertia.share({ user: { id: user?.id, email: user?.email } })
+    inertia.share({
+      appName: 'My App',
+      user: (ctx) => ctx.auth?.user
+    })
   }
 }
 ```


### PR DESCRIPTION
This PR updates the Inertia middleware example in the AdonisJS documentation: https://docs.adonisjs.com/guides/views-and-templates/inertia#share-from-a-middleware