### PR TITLE
docs: update code snippet for E_MAIL_TRANSPORT_ERROR

### DIFF
--- a/content/docs/references/exceptions.md
+++ b/content/docs/references/exceptions.md
@@ -347,7 +347,7 @@ You may access the network request error using the `error.cause` property. The `
 - **Self handled**: No
 
 ```ts
-import { errors as mailErrors } from '@adonisjs/redis'
+import { errors as mailErrors } from '@adonisjs/mail'
 if (error instanceof mailErrors.E_MAIL_TRANSPORT_ERROR) {
   console.log(error.cause)
 }


### PR DESCRIPTION
previously, the docs suggested the `@adonisjs/redis` package should be used to obtain this error, but the error actually lives in `@adonis/mail`

