### PR TITLE
Fix Redundant Exception Imports in Documentation

### DIFF
--- a/content/docs/basics/exception_handling.md
+++ b/content/docs/basics/exception_handling.md
@@ -190,7 +190,7 @@ node ace make:exception UnAuthorized
 ```
 
 ```ts
-import { Exception } from '@adonisjs/core'
+import { Exception } from '@adonisjs/core/exceptions'
 
 export default class UnAuthorizedException extends Exception {}
 ```
@@ -209,7 +209,7 @@ throw new UnAuthorizedException('You are not authorized', {
 The error and status codes can also be defined as static properties on the exception class. The static values will be used if no custom value is defined when throwing the exception.
 
 ```ts
-import { Exception } from '@adonisjs/core'
+import { Exception } from '@adonisjs/core/exceptions'
 export default class UnAuthorizedException extends Exception {
   static status = 403
   static code = 'E_UNAUTHORIZED'
@@ -223,7 +223,7 @@ To self-handle the exception, you can define the `handle` method on the exceptio
 The `error.handle` method receives an instance of the error as the first argument and the HTTP context as the second argument.
 
 ```ts
-import { Exception } from '@adonisjs/core'
+import { Exception } from '@adonisjs/core/exceptions'
 import { HttpContext } from '@adonisjs/core/http'
 
 export default class UnAuthorizedException extends Exception {
@@ -238,7 +238,7 @@ export default class UnAuthorizedException extends Exception {
 You can implement the `report` method on the exception class to self-handle the exception reporting. The report method receives an instance of the error as the first argument and the HTTP context as the second argument.
 
 ```ts
-import { Exception } from '@adonisjs/core'
+import { Exception } from '@adonisjs/core/exceptions'
 import { HttpContext } from '@adonisjs/core/http'
 
 export default class UnAuthorizedException extends Exception {


### PR DESCRIPTION
This pull request addresses an issue in the AdonisJS documentation where the Exception class is imported redundantly from both `@adonisjs/core` and `@adonisjs/core/exceptions`. This correction streamlines the import statements across various sections of the documentation to enhance clarity and maintain consistency.

## Impact
- **Clarity and Readability**: Reduces confusion by ensuring that Exception is consistently imported from the same module across the documentation.