### PR TITLE
Update section "Adding custom methods to REPL" in repl.md

### DIFF
--- a/content/docs/digging_deeper/repl.md
+++ b/content/docs/digging_deeper/repl.md
@@ -99,7 +99,7 @@ You can add custom methods to the REPL using `repl.addMethod`. The method accept
 For demonstration, let's create a [preload file](../concepts/adonisrc_file.md#preloads) file and define a method to import all models from the `./app/models` directory.
 
 ```sh
-node ace make:preload repl --env=repl
+node ace make:preload repl -e=repl
 ```
 
 ```ts


### PR DESCRIPTION
The section `Adding custom methods to REPL` shows a snippet that is outdated, since the `--env` no exists.

```sh
node ace make:preload repl --env=repl
```

This PR replaces the above snippet by


```sh
node ace make:preload repl -e=repl
```