### PR TITLE
chore: Corrected pathname for silent_auth_middleware

### DIFF
--- a/content/docs/authentication/session_guard.md
+++ b/content/docs/authentication/session_guard.md
@@ -191,7 +191,7 @@ import router from '@adonisjs/core/services/router'
 
 router.use([
   // ...
-  () => import('app/middleware/silent_auth')
+  () => import('#middleware/silent_auth_middleware')
 ])
 ```
 


### PR DESCRIPTION
The import was wrong, so I updated it to reflect the new(?) structure.

