### PR TITLE
feat: add pagination to doc

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -252,41 +252,77 @@ progress[value]::-webkit-progress-value {
 }
 
 .pagination {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
+  flex-direction: column-reverse;
   gap: 20px;
   margin-top: 64px;
 }
 
+@media (min-width: 480px) {
+  .pagination {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
 .pagination .button {
-  display: grid;
-  place-items: center;
-  padding: 10px;
-  border-radius: 5px;
+  display: flex;
+  padding: 20px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--neutral-gray-6);
   background-color: var(--neutral-gray-5);
   color: var(--neutral-gray-11);
   text-align: center;
   text-decoration: none;
 }
 
+.pagination .button:nth-child(1),
+.pagination .button:nth-child(2) {
+  flex-direction: column;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
 .pagination .button:nth-child(1) {
-  grid-template-columns: fit-content(100%) 1fr;
+  text-align: start;
 }
 
 .pagination .button:nth-child(2) {
-  grid-template-columns: 1fr fit-content(100%);
+  flex-direction: column-reverse;
+  place-items: end;
+  text-align: end;
+}
+
+@media (min-width: 480px) {
+  .pagination .button:nth-child(1),
+  .pagination .button:nth-child(2) {
+    display: grid;
+    gap: 0;
+    padding: 10px;
+    place-items: center;
+    text-align: center;
+  }
+
+  .pagination .button:nth-child(1) {
+    grid-template-columns: fit-content(100%) 1fr;
+  }
+
+  .pagination .button:nth-child(2) {
+    grid-template-columns: 1fr fit-content(100%);
+  }
 }
 
 .pagination .button:hover {
   background-color: var(--neutral-gray-6);
 }
 
-.pagination .category, .pagination .title {
+.pagination .category,
+.pagination .title {
   margin: 0;
 }
 
 .pagination .category {
-  color: var(--neutral-gray-9);
+  color: var(--violet-10);
   font-size: 13px;
   font-weight: 500;
 }

--- a/assets/app.css
+++ b/assets/app.css
@@ -250,3 +250,49 @@ progress[value]::-webkit-progress-value {
   text-align: right;
   display: block;
 }
+
+.pagination {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-top: 64px;
+}
+
+.pagination .button {
+  display: grid;
+  place-items: center;
+  padding: 10px;
+  border-radius: 5px;
+  background-color: var(--neutral-gray-5);
+  color: var(--neutral-gray-11);
+  text-align: center;
+  text-decoration: none;
+}
+
+.pagination .button:nth-child(1) {
+  grid-template-columns: fit-content(100%) 1fr;
+}
+
+.pagination .button:nth-child(2) {
+  grid-template-columns: 1fr fit-content(100%);
+}
+
+.pagination .button:hover {
+  background-color: var(--neutral-gray-6);
+}
+
+.pagination .category, .pagination .title {
+  margin: 0;
+}
+
+.pagination .category {
+  color: var(--neutral-gray-9);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.pagination .title {
+  color: var(--neutral-gray-11);
+  font-size: 14px;
+  font-weight: 600;
+}

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -80,6 +80,24 @@ edge.global('getSections', function (collection: Collection, entry: CollectionEn
     .all()
 })
 
+edge.global('getPagination', function (collection: Collection, entry: CollectionEntry) {
+  const entries = collection.all()
+  const currentIndex = entries.findIndex((item) => item.permalink === entry.permalink)
+
+  return {
+    previous: {
+      category: entries[currentIndex - 1]?.meta.category,
+      title: entries[currentIndex - 1]?.title,
+      url: entries[currentIndex - 1]?.permalink,
+    },
+    next: {
+      category: entries[currentIndex + 1]?.meta.category,
+      title: entries[currentIndex + 1]?.title,
+      url: entries[currentIndex + 1]?.permalink,
+    },
+  }
+})
+
 /**
  * Configuring rendering pipeline
  */

--- a/templates/docs.edge
+++ b/templates/docs.edge
@@ -27,6 +27,7 @@
       })
         @!component('docs::doc_errors', { messages: file.messages })
         @!component('dimer_contents', { nodes: file.ast.children, pipeline })~
+        @!component('partials/pagination', getPagination(collection, entry))
       @end
 
       @if(file.toc)

--- a/templates/partials/arrow.edge
+++ b/templates/partials/arrow.edge
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="18" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  @if (direction === 'left')
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+  @else
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+  @endif
+</svg>

--- a/templates/partials/pagination.edge
+++ b/templates/partials/pagination.edge
@@ -1,0 +1,25 @@
+<hr />
+<div class="pagination">
+  @if (previous.url)
+    <a href="{{ previous.url }}" class="button">
+      @!component('partials/arrow', { direction: 'left' })
+      <div>
+        <p class="category">{{ previous.category }}</p>
+        <p class="title">{{ previous.title }}</p>
+      </div>
+    </a>
+  @else
+    <div></div>
+  @endif
+  @if (next.url)
+    <a href="{{ next.url }}" class="button">
+      <div>
+        <p class="category">{{ next.category }}</p>
+        <p class="title">{{ next.title }}</p>
+      </div>
+      @!component('partials/arrow')
+    </a>
+  @else
+    <div></div>
+  @endif
+</div>


### PR DESCRIPTION
Hello 👋 

This is a PR to solve issue #34 .

I've added an edge global to handle the pagination called `getPagination` and called it inside `docs.edge` within the component pagination.

I'll share some screenshot of what it looks like.

Right now on desktop it looks like this : 
![image](https://github.com/user-attachments/assets/d53ff808-8def-4e1b-8856-ad40368bcca7)

When you hover a button it gets a little bit brighter.

<img src="https://github.com/user-attachments/assets/828f604b-6b9e-42b4-86ab-17986241af8b" width="300" />
<img src="https://github.com/user-attachments/assets/c7eefc68-43a1-41e7-a8f3-a82625eb674c" width="300" />

The main "issue" here is when text takes a lot of place it looks really tight in mobile : 
<img src="https://github.com/user-attachments/assets/918d0bc8-85bb-460a-b2a7-e76543e09e63" width="300" />

Eventually in mobile, text can be align left / right , i can edit it , here's how it looks like : 
<img src="https://github.com/user-attachments/assets/8b5be9eb-1156-45a2-9e77-d5c5c5750324" width="300" />

Tell me if you've got any suggestions ! 😄 


