### PR TITLE
docs: Make clear which header to use for XSRF

### DIFF
--- a/content/docs/security/securing_ssr_applications.md
+++ b/content/docs/security/securing_ssr_applications.md
@@ -189,7 +189,7 @@ enableXsrfCookie
 
 When enabled, Shield will store the CSRF token inside an encrypted cookie named `XSRF-TOKEN`, which can be read by the frontend JavaScript code.
 
-This allows frontend request libraries like Axios to read the `XSRF-TOKEN` automatically and set it as a header when making Ajax requests without server-rendered forms.
+This allows frontend request libraries like Axios to read the `XSRF-TOKEN` automatically and set it as a `X-XSRF-TOKEN` header when making Ajax requests without server-rendered forms.
 
 You must keep the `enableXsrfCookie` disabled if you are not triggering Ajax requests programmatically.
 


### PR DESCRIPTION
Just a little improvement for the docs to make it clear that adonis reads the `X-XSRF-Token` header when using `enableXsrfCookie`.
This was made clear in the v5 docs, but no mention of it in v6.