### PR TITLE
Update browser_tests.md

### DIFF
--- a/content/docs/testing/browser_tests.md
+++ b/content/docs/testing/browser_tests.md
@@ -252,12 +252,7 @@ export const plugins: Config['plugins'] = [
 ]
 ```
 
-If you are using session-based authentication, then make sure to switch the session driver to an in-memory store.
-
-```dotenv
-// title: .env.test
-SESSION_DRIVER=memory
-```
+If you are using session-based authentication, make sure to also set up the session plugin. See [Populating session store - Setup](#setup-1).
 
 That's all. Now, you may login users using the `loginAs` method. The method accepts the user object as the only argument and marks the user as logged in the current browser context.
 


### PR DESCRIPTION
The instructions for making the auth plugin work together with session auth were not working as they did not mention that the session plugin was a requirement.

I've changed the instructions to point to the session plugin instructions instead. The part about setting the session driver have been removed since it was now redundant.