### PR TITLE
docs(concepts): correct property name from isStarted to isReady

### DIFF
--- a/content/docs/concepts/application_lifecycle.md
+++ b/content/docs/concepts/application_lifecycle.md
@@ -68,7 +68,7 @@ export default class GreetCommand extends BaseCommand {
   }
   
   async run() {
-    console.log(this.app.isStarted) // true
+    console.log(this.app.isReady) // true
   }
 }
 ```


### PR DESCRIPTION
isStarted doesn't seem to exist. Shouldn't it be isReady instead?