### PR TITLE
Correct the SSR config

### DIFF
--- a/content/docs/views-and-templates/inertia.md
+++ b/content/docs/views-and-templates/inertia.md
@@ -950,7 +950,7 @@ import { defineConfig } from '@adonisjs/inertia'
 export default defineConfig({
   ssr: {
     enabled: true,
-    pages: (ctx, page) => page.startsWith('admin')
+    pages: (ctx, page) => !page.startsWith('admin')
   }
 })
 ```


### PR DESCRIPTION
The "!" character is missing in the inertia config to specify that all routes starting by "admin" are not rendered by the server. Otherwise, it should be preferable to change the example in the "SSR Allowlist" description.

