### PR TITLE
fix: correct configuration examples in Inertia documentation

### DIFF
--- a/content/docs/views-and-templates/inertia.md
+++ b/content/docs/views-and-templates/inertia.md
@@ -147,8 +147,8 @@ createInertiaApp({
   title: (title) => {{ `${title} - ${appName}` }},
   resolve: (name) => {
     return resolvePageComponent(
-      `./pages/${name}.vue`,
-      import.meta.glob<DefineComponent>('./pages/**/*.vue'),
+      `../pages/${name}.vue`,
+      import.meta.glob<DefineComponent>('../pages/**/*.vue'),
     )
   },
   setup({ el, App, props, plugin }) {
@@ -822,8 +822,8 @@ export default function render(page) {
     page,
     render: renderToString,
     resolve: (name) => {
-      const pages = import.meta.glob<DefineComponent>('./pages/**/*.vue')
-      return pages[`./pages/${name}.vue`]()
+      const pages = import.meta.glob<DefineComponent>('../pages/**/*.vue')
+      return pages[`../pages/${name}.vue`]()
     },
 
     setup({ App, props, plugin }) {
@@ -898,7 +898,7 @@ export default defineConfig({
   // ...
   ssr: {
     enabled: true,
-    entrypoint: 'inertia/app/ssr.tsx'
+    entrypoint: 'inertia/app/ssr.ts'
   }
 })
 ```
@@ -916,7 +916,7 @@ export default defineConfig({
     inertia({
       ssr: {
         enabled: true,
-        entrypoint: 'inertia/app/ssr.tsx'
+        entrypoint: 'inertia/app/ssr.ts'
       }
     })
   ]


### PR DESCRIPTION
The examples for inertia in the documentation didn’t seem to match the project created by `npm init adonisjs@latest` . This PR fixes some of that.