### PR TITLE
feat(social authentication): added linkedin openid connect config

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -164,6 +164,10 @@ html.dark {
   border-radius: 0 0 7px 7px;
 }
 
+.disclosure_wrapper .disclosure_panel p {
+  margin-top: 12px;
+}
+
 @media (min-width: 1440px) {
   .markdown .table_expanded {
     max-width: 120%;

--- a/content/docs/authentication/social_authentication.md
+++ b/content/docs/authentication/social_authentication.md
@@ -416,7 +416,9 @@ The following is the complete configuration reference for all the drivers. You c
 
 :::
 
-:::disclosure{title="LinkedIn config"}
+:::disclosure{title="LinkedIn config (deprecated)"}
+
+This configuration is deprecated in compliance with the updated [LinkedIn OAuth requirements](https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin).
 
 ```ts
 {
@@ -427,6 +429,22 @@ The following is the complete configuration reference for all the drivers. You c
 
     // LinkedIn specific
     scopes: ['r_emailaddress', 'r_liteprofile'],
+  })
+}
+```
+:::
+
+:::disclosure{title="LinkedIn Openid Connect config"}
+
+```ts
+{
+  linkedin: services.linkedinOpenidConnect({
+    clientId: '',
+    clientSecret: '',
+    callbackUrl: '',
+
+    // LinkedIn specific
+    scopes: ['openid', 'profile', 'email'],
   })
 }
 ```


### PR DESCRIPTION
Added the LinkedIn OpenID Connect configuration to the social authentication section to support the new provider created in Ally, enabling connections to LinkedIn using the OpenID Connect method.