### PR TITLE
fix: cache usage example code

### DIFF
--- a/content/docs/digging_deeper/cache.md
+++ b/content/docs/digging_deeper/cache.md
@@ -108,7 +108,7 @@ import router from '@adonisjs/core/services/router'
 router.get('/user/:id', async ({ params }) => {
   return cache.getOrSet({
     key: `user:${params.id}`,
-    duration: '5m',
+    ttl: '5m',
     factory: async () => {
       const user = await User.find(params.id)
       return user.toJSON()


### PR DESCRIPTION
For the cache docs, the usage example uses an invalid get or set option: `duration` 

Updated it to: `ttl`

Related type export I used to verify the correct options: 
https://github.com/Julien-R44/bentocache/blob/b739d88efabab1122706cd1bf9c38c0aa9f5fca7/packages/bentocache/src/types/options/methods_options.ts#L6-L9