### PR TITLE
Remove deprecated method `lazy` from inertia example

### DIFF
--- a/content/docs/views-and-templates/inertia.md
+++ b/content/docs/views-and-templates/inertia.md
@@ -546,7 +546,7 @@ export default class UsersController {
       // NEVER included on first visit.
       // OPTIONALLY included on partial reloads.
       // ONLY evaluated when needed
-      users: inertia.lazy(() => User.all())
+      users: inertia.optional(() => User.all())
     }),
   }
 }


### PR DESCRIPTION
# Description

Hey folks, I was adding some lazy data eval in my project here and noticed that the method `inertia.lazy` seems to be deprecated, altough it is still being used as an example in the official docs: 

![image](https://github.com/user-attachments/assets/a9090970-38ef-4ee0-a841-7be38e9ec0ae)

![image](https://github.com/user-attachments/assets/4385d87b-b4a1-414c-80b2-c386851f0240)

