### PR TITLE
Fix typo in prompts options table

### DIFF
--- a/content/docs/ace/prompts.md
+++ b/content/docs/ace/prompts.md
@@ -168,7 +168,7 @@ Validate the user input. Returning `true` from the method will pass the validati
 
 ```ts
 {
-  format(value) {
+  validate(value) {
     return value.length > 6
     ? true
     : 'Model name must be 6 characters long'


### PR DESCRIPTION
The code snippet for `validate` accidentally used the `format` label.

<img width="738" alt="Screenshot 2025-05-21 at 20 40 50" src="https://github.com/user-attachments/assets/279b00b6-fbd3-4d64-8c31-c071b7c9cfdf" />
