### PR TITLE
fix: correct method name for deleting cache by tags and clean up whit…

### DIFF
--- a/content/docs/digging_deeper/cache.md
+++ b/content/docs/digging_deeper/cache.md
@@ -46,7 +46,7 @@ import { defineConfig, store, drivers } from '@adonisjs/cache'
 
 const cacheConfig = defineConfig({
   default: 'redis',
-  
+
   stores: {
     /**
      * Cache data only on DynamoDB
@@ -89,7 +89,7 @@ In `config/cache.ts`, you must specify a `connectionName`. This property should 
 
 ### Other drivers
 
-You can use other drivers such as `memory`, `dynamodb`, `kysely` and `orchid`. 
+You can use other drivers such as `memory`, `dynamodb`, `kysely` and `orchid`.
 
 See [Cache Drivers](https://bentocache.dev/docs/cache-drivers) for more information.
 
@@ -132,7 +132,7 @@ await bento.getOrSet({
   tags: ['tag-1', 'tag-2']
 });
 
-await bento.deleteByTags({ tags: ['tag-1'] });
+await bento.deleteByTag({ tags: ['tag-1'] });
 ```
 
 ### Namespaces
@@ -145,7 +145,7 @@ const users = bento.namespace('users')
 users.set({ key: '32', value: { name: 'foo' } })
 users.set({ key: '33', value: { name: 'bar' } })
 
-users.clear() 
+users.clear()
 ```
 
 ### Grace period
@@ -259,7 +259,7 @@ await cache.pull({ key: 'username' })
 
 await cache.delete({ key: 'username' })
 await cache.deleteMany({ keys: ['products', 'users'] })
-await cache.deleteByTags({ tags: ['products', 'users'] })
+await cache.deleteByTag({ tags: ['products', 'users'] })
 
 await cache.clear()
 ```


### PR DESCRIPTION
## Description
This PR makes two small documentation corrections :

1. Fixes the example in the Cache section to correctly reference the `deleteByTag` method, which matches the actual BentoCache API implementation :

- In the [`BentoCache`](https://github.com/Julien-R44/bentocache/blob/daf97f0e225423407a68d9937b9d5d54b20931f4/packages/bentocache/src/bento_cache.ts#L221) class:
```ts
async deleteByTag(options: DeleteByTagOptions): Promise<boolean> {
  return this.use().deleteByTag(options)
}
```

- In the [Cache](https://github.com/Julien-R44/bentocache/blob/daf97f0e225423407a68d9937b9d5d54b20931f4/packages/bentocache/src/cache/cache.ts#L205) class implementation:
```ts
async deleteByTag(rawOptions: DeleteByTagOptions): Promise<boolean> {
  const tags = rawOptions.tags
  const options = this.#stack.defaultOptions.cloneWith(rawOptions)

  this.#options.logger.logMethod({ method: 'deleteByTag', cacheName: this.name, tags, options })

  return await this.#stack.createTagInvalidations(tags)
}
```

2. Removes unnecessary trailing whitespace.

## Changes
- Corrected method name in code example of the documentation from `deleteByTags` to `deleteByTag`

## Why
These changes ensure the documentation accurately reflects the BentoCache API, helping to prevent confusion for users who might use examples.