### PR TITLE
fixed typo in routing.md documentation

### DIFF
--- a/content/docs/basics/routing.md
+++ b/content/docs/basics/routing.md
@@ -374,7 +374,7 @@ The routes inside a group must have names before you can prefix them.
 // title: start/routes.ts
 router
   .group(() => {
-    route
+    router
       .get('users', () => {})
       .as('users.index') // final name - api.users.index
   })
@@ -388,13 +388,13 @@ In the case of nested groups, the names will be prefixed from the outer to the i
 // title: start/routes.ts
 router
   .group(() => {
-    route
+    router
       .get('users', () => {})
       .as('users.index') // api.users.index
 
     router
       .group(() => {
-        route
+        router
           .get('payments', () => {})
           .as('payments.index') // api.commerce.payments.index
       })


### PR DESCRIPTION
When reading through the routing guide on the AdonisJS website, I was confused in the grouping section because "route" was being used instead of "router." This seems like a typo to me.

