### PR TITLE
Fix scaffolding stub

### DIFF
--- a/content/docs/concepts/scaffolding.md
+++ b/content/docs/concepts/scaffolding.md
@@ -235,7 +235,7 @@ node ace make:controller invoice --feature=billing
 // title: Controller stub
 {{#var controllerName = generators.controllerName(entity.name)}}
 // insert-start
-{{#var featureDirectoryName = generators.makePath('features', flags.feature)}}
+{{#var featureDirectoryName = flags.feature}}
 // insert-end
 {{#var controllerFileName = generators.controllerFileName(entity.name)}}
 {{{
@@ -244,7 +244,7 @@ node ace make:controller invoice --feature=billing
     to: app.httpControllersPath(entity.path, controllerFileName)
     // delete-end
     // insert-start
-    to: app.makePath(featureDirectoryName, entity.path, controllerFileName)
+    to: app.makePath('features', featureDirectoryName, controllerFileName)
     // insert-end
   })
 }}}


### PR DESCRIPTION
Modified the way the feature directory name is generated in the controller stub to fix the logic in the scaffolding process.
`generators.makePath()` is not a function should be `app.makePath()`
`app.makePath()` can't have another `app.makePath()` inside it
Tested it while creating this package https://github.com/adonisjs-community/modules

