### PR TITLE
Update deployment docs to use more recent Node.js version

### DIFF
--- a/content/docs/getting_started/deployment.md
+++ b/content/docs/getting_started/deployment.md
@@ -27,7 +27,7 @@ Once you have created the production build, you may copy the `./build` folder to
 If you are using Docker to deploy your application, you may create a Docker image using the following `Dockerfile`.
 
 ```dockerfile
-FROM node:20.12.2-alpine3.18 AS base
+FROM node:22.16.0-alpine3.22 AS base
 
 # All deps stage
 FROM base AS deps


### PR DESCRIPTION
The node.js in the dockerfile being 20 instead of 22 will cause applications using ally to experience errors where requests to OAuth providers hang.

