### PR TITLE
fix optionalWhen example

### DIFF
--- a/content/docs/getting_started/environment_variables.md
+++ b/content/docs/getting_started/environment_variables.md
@@ -122,7 +122,7 @@ The `schema.string` method ensures the value is a valid string. Empty strings fa
 
 // Mark it as optional with a condition
 {
-  APP_KEY: Env.schema.string.optionalWhen(process.env.NODE_ENV === 'production')
+  APP_KEY: Env.schema.string.optionalWhen(() => process.env.NODE_ENV === 'production')
 }
 ```
 
@@ -182,7 +182,7 @@ The string representations of `'true'`, `'1'`, `'false'`, and `'0'` are cast to 
 
 // Mark it as optional with a condition
 {
-  CACHE_VIEWS: Env.schema.boolean.optionalWhen(process.env.NODE_ENV === 'production')
+  CACHE_VIEWS: Env.schema.boolean.optionalWhen(() => process.env.NODE_ENV === 'production')
 }
 ```
 
@@ -202,7 +202,7 @@ The `schema.number` method ensures the value is a valid number. The string repre
 
 // Mark it as optional with a condition
 {
-  PORT: Env.schema.number.optionalWhen(process.env.NODE_ENV === 'production')
+  PORT: Env.schema.number.optionalWhen(() => process.env.NODE_ENV === 'production')
 }
 ```
 
@@ -231,7 +231,7 @@ The `schema.enum` method validates the environment variable against one of the p
     .schema
     .enum
     .optionalWhen(
-      process.env.NODE_ENV === 'production',
+      () => process.env.NODE_ENV === 'production',
       ['development', 'production'] as const
     )
 }


### PR DESCRIPTION
The docs currently show this example:
```
// Mark it as optional with a condition
{
  CACHE_VIEWS: Env.schema.boolean.optionalWhen(process.env.NODE_ENV === 'production')
}
```

If `NODE_ENV` is set only in `.env`, `process.env.NODE_ENV` is `undefined` when the schema is created. This makes the condition evaluate incorrectly and triggers `EnvValidationException`.

This PR updates the example to use the function form, which defers evaluation until after `.env` is loaded:
```
// Mark it as optional with a condition
{
  CACHE_VIEWS: Env.schema.boolean.optionalWhen(() => process.env.NODE_ENV === 'production')
}
```
