### PR TITLE
Correct keyAttributName in DynamoDB config

### DIFF
--- a/content/docs/basics/session.md
+++ b/content/docs/basics/session.md
@@ -295,7 +295,7 @@ Additionally, you may define a custom table name and key attribute name.
 ```ts
 stores.dynamodb({
   tableName: 'Session'
-  keyAttributName: 'key'
+  keyAttribute: 'key'
 })
 ```
 


### PR DESCRIPTION
Fix docs to use `keyAttribute` instead of old `keyAttributName` for DynamoDB session store config, matching current API in [@adonisjs/session](https://github.com/adonisjs/session/blob/7.x/src/types.ts#L118C3-L118C15) source.