### PR TITLE
Fix container binding example typo

### DIFF
--- a/content/docs/concepts/dependency_injection.md
+++ b/content/docs/concepts/dependency_injection.md
@@ -242,7 +242,7 @@ class MyFakeCache {
 }
 
 app.container.bind('cache', function () {
-  return new MyCache()
+  return new MyFakeCache()
 })
 
 const cache = await app.container.make('cache')


### PR DESCRIPTION
The original code defines a class named `MyFakeCache`, but the binding returns an instance of `MyCache`, which is undefined and could confuse readers or cause runtime errors.
