### PR TITLE
docs: update Svelte Inertia setup to v5 syntax

### DIFF
--- a/content/docs/views-and-templates/inertia.md
+++ b/content/docs/views-and-templates/inertia.md
@@ -189,6 +189,7 @@ createInertiaApp({
 ```ts
 // title: Svelte
 import { createInertiaApp } from '@inertiajs/svelte'
+import { mount } from 'svelte'
 import { resolvePageComponent } from '@adonisjs/inertia/helpers'
 
 const appName = import.meta.env.VITE_APP_NAME || 'AdonisJS'
@@ -206,7 +207,7 @@ createInertiaApp({
   },
 
   setup({ el, App, props }) {
-    new App({ target: el, props })
+    mount(App, { target: el, props })
   },
 })
 ```


### PR DESCRIPTION
Update Svelte Inertia example to Svelte 5 syntax

Updates the setup code to use Svelte 5's new `mount()` API instead 
of the v4 `new App()` constructor.